### PR TITLE
Adding node_modules for server.js to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ Temporary Items
 
 WWW/node_modules
 WWW/js/build
+node_modules/


### PR DESCRIPTION
We don't want the `node_modules` directory for `server.js` in the repository, we should be ignoring them like we are for the `WWW` directory.
